### PR TITLE
Use /var/log/syslog instead of /var/log/message

### DIFF
--- a/ptrap
+++ b/ptrap
@@ -117,7 +117,7 @@ elif [ -z "$MONITOR_TCP" -a -n "$TCP_ONLY_SYN" ]; then
 elif [ $(id -u) -ne 0 ]; then
   echo "You must be root to execute this script." >&2
   exit 6
-elif [ ! -f /var/log/messages ]; then
+elif [ ! -f /var/log/syslog ]; then
   echo "'/var/log/message' was not found." >&2
   echo "This program depends on syslog outputting messages to that file." >&2
   echo "Please configure your system accordingly." >&2
@@ -202,7 +202,7 @@ teardown_lock_directory () {
 
 monitor_syslog() {
 	log "Starting syslog monitoring..."
-	tail -f -s "$TAIL_INTERVAL_S" /var/log/messages | grep --line-buffered "$IPTABLES_IDENTIFIER" | while read LINE; do
+	tail -f -s "$TAIL_INTERVAL_S" /var/log/syslog | grep --line-buffered "$IPTABLES_IDENTIFIER" | while read LINE; do
 		PROTOCOL=$(echo "$LINE" | grep -o -E "PROTO=\w*" | cut -d= -f2) || PROTOCOL=""
 		SOURCE_PORT=$(echo "$LINE" | grep -o -E "SPT=[0-9]+" | cut -d= -f2) || SOURCE_PORT=""
 		MATCHING_PID=$($PRG_LSOF -i ${PROTOCOL}:${SOURCE_PORT} | tail -n1 | awk '{print $2}') || MATCHING_PID=""


### PR DESCRIPTION
Rsyslog has changed where the logs are being written to.

More info here https://bugs.launchpad.net/ubuntu/+source/rsyslog/+bug/794727